### PR TITLE
尝试做了个免修不免考获取模块

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# 默认忽略的文件
+/shelf/
+/workspace.xml
+# 基于编辑器的 HTTP 客户端请求
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/nju-schedule-ics.iml" filepath="$PROJECT_DIR$/.idea/nju-schedule-ics.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/nju-schedule-ics.iml
+++ b/.idea/nju-schedule-ics.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="EMPTY_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/src/nju/getexampted.rs
+++ b/src/nju/getexampted.rs
@@ -1,0 +1,61 @@
+/*
+ * 获取免修不免考的课程
+ */
+
+use super::login::LoginCredential;
+use super::getcourse::build_client;
+use anyhow::anyhow;
+use reqwest_middleware::ClientWithMiddleware;
+use std::collections::HashMap;
+
+/**
+ * Attempted to build a function to get exampted course
+ * 免修不免考获取模块（尝试版）
+ * 2025.2.28 AritxOnly
+ */
+
+pub async fn get_exampted_raw(auth: &LoginCredential) -> Result<String, anyhow::Error> {
+    let client = build_client(auth)?;
+
+    // 首先访问主页面获取必要的cookies
+    let _ = client
+        .get("https://ehallapp.nju.edu.cn/jwapp/sys/mtxkbl/*default/index.do")
+        .send()
+        .await?;
+
+    // 获取免修不免考课程数据
+    let form = HashMap::from([
+        ("pageSize", "9999"),
+        ("pageNumber", "1"),
+    ]);
+
+    let resp = client
+        .post("https://ehallapp.nju.edu.cn/jwapp/sys/mtxkbl/modules/mtsq/cxmtxkxx.do")
+        .form(&form)
+        .send()
+        .await?
+        .text()
+        .await?;
+
+    Ok(resp)
+}
+
+pub async fn get_exampted_data(resp: &String) -> Result<Vec<String>, anyhow::Error> {
+    let mut course_names = Vec::new();
+    
+    let document = Document::from(resp);
+    
+    let table = document.find(Attr("id", "tablemtsq-index-table")).next();
+
+    if let Some(table_node) = table {
+        for row in table_node.find(Name("tr")) {
+            if let Some(cell) = row.find(Name("td")).filter(|td| td.text() == "课程名").next() {
+                if let Some(course_name) = cell.next_sibling() {
+                    course_names.push(course_name.text());
+                }
+            }
+        }
+    }
+
+    Ok(course_names)
+}

--- a/src/nju/mod.rs
+++ b/src/nju/mod.rs
@@ -3,3 +3,5 @@ pub mod getcourse;
 
 /* 登陆到南京大学统一认证，获取cookie */
 pub mod login;
+
+pub mod getexampted;


### PR DESCRIPTION
仿照小许学长的getcourse.rs写了以下两个模块

```rust
pub async fn get_exampted_raw(auth: &LoginCredential) -> Result<String, anyhow::Error> // 得到免修不免考页面的响应

pub async fn get_exampted_data(resp: &String) -> Result<Vec<String>, anyhow::Error> // 将响应尝试解析成一个由免修不免考课程名构成的一个动态数组
```